### PR TITLE
[Android]: Android 16 KB Page Size Support

### DIFF
--- a/android/CMakeLists.txt
+++ b/android/CMakeLists.txt
@@ -47,5 +47,6 @@ target_link_libraries(
         log
         android
 )
+target_link_options(${PACKAGE_NAME} PRIVATE "-Wl,-z,max-page-size=16384")
 
 


### PR DESCRIPTION
**What's the Issue?**

This change addresses a critical compatibility issue with new Android devices. Starting with Android 15, devices can now use a larger, more efficient 16 KB memory page size. Our app's native libraries (.so files), including libmqtt.so, were compiled with an old 4 KB alignment. This misalignment will cause our app to crash on any new device that ships with the 16 KB page size.

**Why the Change is Needed**

This is a mandatory update to ensure our app's stability and performance on modern Android hardware. Recompiling our libraries with the new 16 KB alignment is a key step to:

Prevent Crashes: Ensure our app launches and runs correctly on all new devices.

**What Was Changed?**

I added a single line of code to the mqtt library's CMakeLists.txt file. This line applies a specific linker flag that tells the Android build system to correctly align our library's internal structure.

This change forces the linker to align our native code to a 16 KB boundary, which is the required format for modern Android devices. No other code changes were necessary for this fix.

**Testing**

Before Fix

<img width="1219" height="31" alt="Screenshot 2025-08-26 at 11 57 17 PM" src="https://github.com/user-attachments/assets/f678411f-afc5-4a39-9194-6bcf545394cd" />

After Fix

<img width="1190" height="34" alt="Screenshot 2025-08-26 at 11 54 53 PM" src="https://github.com/user-attachments/assets/d39f6571-6633-4b42-895c-c45fcb46b09b" />