### PR TITLE
Fix: iOS NativeEventEmission 

### DIFF
--- a/__mocks__/react-native.ts
+++ b/__mocks__/react-native.ts
@@ -7,6 +7,10 @@ const NativeModules = {
   },
 };
 
+const Platform = {
+  OS: 'ios', // Default to iOS for testing
+};
+
 const mockedMqttClass = jest.fn();
 
 class NativeEventEmitter {
@@ -15,4 +19,4 @@ class NativeEventEmitter {
   }
 }
 
-export { NativeModules, NativeEventEmitter, mockedMqttClass };
+export { NativeModules, NativeEventEmitter, mockedMqttClass, Platform };

--- a/android/src/main/java/com/dream11/mqtt/MqttModuleImpl.kt
+++ b/android/src/main/java/com/dream11/mqtt/MqttModuleImpl.kt
@@ -8,7 +8,7 @@ import com.facebook.react.bridge.ReactContextBaseJavaModule
 import com.facebook.react.bridge.ReactMethod
 import com.facebook.react.bridge.WritableMap
 import com.facebook.react.module.annotations.ReactModule
-import com.facebook.react.modules.core.DeviceEventManagerModule
+import com.facebook.react.modules.core.DeviceEventManagerModule.RCTDeviceEventEmitter
 import java.io.Serializable
 
 @ReactModule(name = MqttModuleImpl.NAME)
@@ -29,6 +29,7 @@ class MqttModuleImpl(reactContext: ReactApplicationContext?) :
     override fun getName(): String {
       return NAME
     }
+
 
     private external fun nativeInstallJSIBindings(runtimePtr: Long)
 
@@ -65,10 +66,10 @@ class MqttModuleImpl(reactContext: ReactApplicationContext?) :
         }
   }
 
-    private fun emitJsiEvent(eventId: String, payload: HashMap<String, Any>) {
+    private fun emitJsiEvent(eventName: String, payload: HashMap<String, Any>) {
         reactApplicationContext
-            .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter::class.java)
-            .emit(eventId, MapUtils.toWritableMap(payload))
+            .getJSModule(RCTDeviceEventEmitter::class.java)
+            .emit(eventName, MapUtils.toWritableMap(payload))
     }
 
     override fun removeMqtt(clientId: String) {
@@ -100,5 +101,10 @@ class MqttModuleImpl(reactContext: ReactApplicationContext?) :
     override fun getConnectionStatusMqtt(clientId: String): String {
         return MqttManager.getConnectionStatusMqtt(clientId)
       Log.d("::::D11MQTT",":::: getConnectionStatusMqtt called via jsi bridge")
+    }
+
+    @ReactMethod
+    fun removeListeners(count: Int) {
+
     }
 }

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -4,7 +4,7 @@ PODS:
     - CocoaMQTT/Core (= 2.1.5)
   - CocoaMQTT/Core (2.1.5):
     - MqttCocoaAsyncSocket (~> 1.0.8)
-  - d11-mqtt (0.0.4):
+  - d11-mqtt (0.0.5):
     - CocoaMQTT (= 2.1.5)
     - RCT-Folly (= 2021.07.22.00)
     - React-Core
@@ -576,7 +576,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   boost: 7dcd2de282d72e344012f7d6564d024930a6a440
   CocoaMQTT: af1bd1e42f81b9f4f9dcf3a8990c42b7c00989b9
-  d11-mqtt: 6d722620217aab13efc7d24180f2b35b84237171
+  d11-mqtt: c2a55bd65e82f6b627d32d3a3a2107ddcadb526e
   DoubleConversion: 5189b271737e1565bdce30deb4a08d647e3f5f54
   FBLazyVector: dc178b8748748c036ef9493a5d59d6d1f91a36ce
   FBReactNativeSpec: d0aaae78e93c89dc2d691d8052a4d2aeb1b461ee
@@ -585,27 +585,27 @@ SPEC CHECKSUMS:
   hermes-engine: 9b9bb14184a11b8ceb4131b09abf634880f0f46d
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   MqttCocoaAsyncSocket: 77d3b74f76228dd5a05d1f9526eab101d415b30c
-  RCT-Folly: 424b8c9a7a0b9ab2886ffe9c3b041ef628fd4fb1
+  RCT-Folly: 8dc08ca5a393b48b1c523ab6220dfdcc0fe000ad
   RCTRequired: f30c3213569b1dc43659ecc549a6536e1e11139e
   RCTTypeSafety: e1ed3137728804fa98bce30b70e3da0b8e23054e
   React: 54070abee263d5773486987f1cf3a3616710ed52
   React-callinvoker: 794ea19cc4d8ce25921893141e131b9d6b7d02eb
-  React-Codegen: be3e687b47ff2f4469a8913a01093994ff4a13b8
-  React-Core: 69fa0a5585518ed7a1bccb6dc2ed59b912f29738
-  React-CoreModules: 7ba5ea7d8fffe4fc270018e47d7335d98e7b7318
-  React-cxxreact: 1100498800597e812f0ce4ec365f4ea47ac39719
+  React-Codegen: 5007be718919c52700ab2722ec91bf37a919a757
+  React-Core: b0bd3fd85d032cd7e32f6d51ad09eb900a112ef9
+  React-CoreModules: 09a612e281b8cada34b237b613a1fbb1ee3c1885
+  React-cxxreact: f52f3a7c8361c005ac4776737b5cf04b94b87852
   React-debug: a5f8180f9f077294a24c4d28280dc05917d872a9
-  React-hermes: b871a77ba1c427ca00f075759dc0cc9670484c94
-  React-jsi: 1f8d073a00264c6a701c4b7b4f4ef9946f9b2455
-  React-jsiexecutor: 5a169b1dd1abad06bed40ab7e1aca883c657d865
+  React-hermes: 55ccf2ba061d95710aba21855925d82c8382c51d
+  React-jsi: 90d3d603f15e7284f056ee0eebac8174d49a51f2
+  React-jsiexecutor: d0e8687f75e16c63c2f5bbe51f58bdbebe9df4b2
   React-jsinspector: 54205b269da20c51417e0fc02c4cde9f29a4bf1a
-  React-logger: f42d2f2bc4cbb5d19d7c0ce84b8741b1e54e88c8
-  React-NativeModulesApple: 3d1fab3decbf21afb13a7a3a297053652765190d
+  React-logger: 81785c91d2fcc517657ff456c106c6d8e9ec4110
+  React-NativeModulesApple: 502d8ef6c6ce543f70d6b92f9ec33bfd88ac2852
   React-perflogger: cb433f318c6667060fc1f62e26eb58d6eb30a627
   React-RCTActionSheet: 0af3f8ac067e8a1dde902810b7ad169d0a0ec31e
   React-RCTAnimation: dae467c667a2364ce91f7f76403a53af67c9f6a8
-  React-RCTAppDelegate: 060e6384fe547e054dd027317d0d8c724bafd6df
-  React-RCTBlob: cfd8a7a290961d0013004f6370467c25f9e29fb5
+  React-RCTAppDelegate: 6ce60dfaccc0356aa7bcc077a64d2879f48f04fd
+  React-RCTBlob: 35eb44de4119c21c7fd1fb16b01f7087dce1b517
   React-RCTImage: af1c6419337d41d1560e9fa26a7285d0144f5c7c
   React-RCTLinking: 2c44416944b824a308bcfe7a4eaed2fbe2cfc47e
   React-RCTNetwork: 2389ec5f6223e1ad9d5a2f52af0de7ba91470384
@@ -614,12 +614,12 @@ SPEC CHECKSUMS:
   React-RCTVibration: d2ba634656f8d806827107089c160717350420eb
   React-rncore: b4d5c811ee67a57f27b148e3bb59643ccee10ce4
   React-runtimeexecutor: 226ebef5f625878d3028b196cbecbbdeb6f208e4
-  React-runtimescheduler: e8591257b9c3ba3f675f9435fd667b7ea9da9ffb
-  React-utils: ca41af4592cb4ed7eb660d33b7d63818561ee118
-  ReactCommon: 7f1c2a847773d16c6ba5fb8224552f4d510a51ba
+  React-runtimescheduler: d5970dfdf48862881c5ba2a41a52cea66e876294
+  React-utils: b74047488a8efe1790b016bd50788b2b0bd4566c
+  ReactCommon: 32f066dc0265a6c65312c276e47dd7ecf6a1a6d9
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
   Yoga: eddf2bbe4a896454c248a8f23b4355891eb720a6
 
 PODFILE CHECKSUM: fb028348e5c9fd9f91ffe087abe901be516f1b99
 
-COCOAPODS: 1.15.2
+COCOAPODS: 1.16.2

--- a/ios/MqttModule.mm
+++ b/ios/MqttModule.mm
@@ -32,12 +32,26 @@ RCT_EXPORT_MODULE(MqttModule)
     return YES;
 }
 
-- (NSArray<NSString *> *)supportedEvents {
-    return @[@"CUSTOM_EVENT"];
-}
+  - (NSArray<NSString *> *)supportedEvents {
+      return @[
+          @"connected",
+          @"disconnected",
+          @"subscribe_success",
+          @"subscribe_failed",
+          @"client_initialize",
+          @"mqtt_error",
+          @"subscription_event"
+      ];
+  }
 
 - (void)sendEventToJs:(NSString * _Nonnull)eventName param:(NSDictionary<NSString *,id> *_Nullable)params {
      [self sendEventWithName:eventName body: params];
+}
+
+RCT_EXPORT_METHOD(removeListeners:(double)count) {
+    // React Native requires this method for NativeEventEmitter
+    // In our case, we don't need to do anything special here
+    // as event listeners are managed by the React Native framework
 }
 
 RCT_EXPORT_METHOD(createMqtt:(NSString *)clientId host:(NSString *)host port:(NSInteger)port enableSsl:(BOOL)enableSsl) {

--- a/ios/mqtt/Mqtt.swift
+++ b/ios/mqtt/Mqtt.swift
@@ -56,7 +56,7 @@ public class Mqtt: NSObject, MqttDelegate {
     
     @objc
     public func getConnectionStatusMqtt(_ clientId: String) -> String {
-        return MqttManager.shared.getConnectionStatusMqtt(clientId)
         print("getConnectionStatusMqtt MQTT CALLED")
+        return MqttManager.shared.getConnectionStatusMqtt(clientId)
     }
 }

--- a/src/Mqtt/EventEmitter.ts
+++ b/src/Mqtt/EventEmitter.ts
@@ -1,4 +1,4 @@
-import { NativeEventEmitter } from 'react-native';
+import { NativeEventEmitter, Platform } from 'react-native';
 import { MqttModule } from '../Modules/mqttModule';
 
 /**
@@ -7,10 +7,12 @@ import { MqttModule } from '../Modules/mqttModule';
  * The singleton pattern is implemented using an Immediately Invoked Function Expression (IIFE).
  */
 export const EventEmitter = (function () {
-  var instance: EventEmitter;
+  var instance: EventEmitter | undefined;
 
   function createInstance() {
-    return new NativeEventEmitter(MqttModule);
+    return new NativeEventEmitter(
+      Platform.OS === 'ios' ? MqttModule : undefined
+    );
   }
 
   return {
@@ -24,6 +26,9 @@ export const EventEmitter = (function () {
         instance = createInstance();
       }
       return instance;
+    },
+    resetInstance: function () {
+      instance = undefined;
     },
   };
 })();

--- a/src/Mqtt/Mqtt.ts
+++ b/src/Mqtt/Mqtt.ts
@@ -14,18 +14,24 @@ export const createMqttClient = (
   config: MqttConfig
 ): Promise<MqttClient | undefined> => {
   const eventEmitter: EventEmitter = EventEmitter.getInstance();
-  const eventName = config.clientId + MQTT_EVENTS.CLIENT_INITIALIZE_EVENT;
+  const eventName = MQTT_EVENTS.CLIENT_INITIALIZE_EVENT;
 
   return new Promise<MqttClient | undefined>((resolve) => {
     const listener = eventEmitter.addListener(
       eventName,
-      (ack: MqttEventsInterface[MQTT_EVENTS.CLIENT_INITIALIZE_EVENT]) => {
-        if (ack.clientInit) {
-          resolve(client);
-        } else {
-          resolve(undefined);
+      (
+        ack: MqttEventsInterface[MQTT_EVENTS.CLIENT_INITIALIZE_EVENT] & {
+          clientId: string;
         }
-        listener.remove();
+      ) => {
+        if (ack.clientId === config.clientId) {
+          if (ack.clientInit) {
+            resolve(client);
+          } else {
+            resolve(undefined);
+          }
+          listener.remove();
+        }
       }
     );
 

--- a/src/__tests__/eventEmitter.test.ts
+++ b/src/__tests__/eventEmitter.test.ts
@@ -1,22 +1,40 @@
 import {
   mockedMqttClass,
   NativeEventEmitter,
+  Platform,
 } from '../../__mocks__/react-native';
 import { MqttModule } from '../Modules/mqttModule';
 import { EventEmitter } from '../Mqtt/EventEmitter';
 
+jest.mock('react-native', () => ({
+  ...jest.requireActual('../../__mocks__/react-native'),
+  Platform: {
+    OS: 'ios', // Default to iOS for testing
+  },
+}));
+
 describe('EventEmitter', () => {
   afterEach(() => {
     jest.resetAllMocks();
+    EventEmitter.resetInstance();
   });
 
-  it('should create a new EventEmitter instance', () => {
+  it('should create a new EventEmitter instance on iOS', () => {
+    (Platform as any).OS = 'ios';
     const instance = EventEmitter.getInstance();
     expect(instance).toBeInstanceOf(NativeEventEmitter);
     expect(mockedMqttClass).toHaveBeenCalledWith(MqttModule);
   });
 
+  it('should create a new EventEmitter instance on Android', () => {
+    (Platform as any).OS = 'android';
+    const instance = EventEmitter.getInstance();
+    expect(instance).toBeInstanceOf(NativeEventEmitter);
+    expect(mockedMqttClass).toHaveBeenCalledWith(undefined);
+  });
+
   it('should always return the same instance for multiple calls', () => {
+    (Platform as any).OS = 'ios';
     const firstInstance = EventEmitter.getInstance();
     const secondInstance = EventEmitter.getInstance();
     expect(secondInstance).toBe(firstInstance);


### PR DESCRIPTION
What's the Issue?
Addressing the issues reported in Issues: #8 and #22, '<EmittedEvent> is not a supported event type in MqttModule' 

Why the Change is Needed
Example project would throw fatal error on initialization. 

What Was Changed?
Updated NativeEventEmitter listeners in javascript to accept pre-specified event types and removed dynamic naming based on clientId and eventId. Updated native module code in compliance with updated event types and included clientID/eventID in event body. Updated Android event emission in accordance and in doing so migrated from the deprecated deviceEmitter to the now standard NativeEventEmitter.  

Testing
Before fix: 
- checkout main
- run yarn example start & yarn example ios
- Project will build but immediately encounter fatal error. 

After Fix:
Repeat above steps with PR branch